### PR TITLE
Enhance script to selectively start some of the OCF servers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,5 +87,14 @@ The (alleged, not verified yet) advantage of running with the `--network host` p
 
 *Note:* this uses plain HTTP. It is possible to use HTTPS by modifying the [startup script](gateway/start-smarthome-in-docker.sh) and passing the `-s` parameter to the `iot-rest-api-server` startup script.
 
+By default, the [startup script](ocf-servers/start-ocf-servers-in-docker.sh) starts all the OCF servers. In order to selectively start some of the OCF servers, follow the steps below:
+**1.** Make a copy of the `ocf-servers/ocf-server.conf.template` file and renamed it to `ocf-servers/ocf-server.conf`
+**2.** Configure `ocf-servers/ocf-server.conf` adhere to the formats in the template. Put the OCF server name in the 1st column and the total number of the specified server type in the 2nd column. If the configuration file format is not compliant or it does not exist in the same directory of the script file, the [startup script](ocf-servers/start-ocf-servers-in-docker.sh) skips parsing and starts all OCF servers instead.
+**3.** Share the configuration file on the host with the container process    
+```
+$ docker run -v <path/to/ocf-server.conf/on/host>:/opt/SmartHome-Demo/ocf-servers/ocf-server.conf smarthome-sensors:v1
+```
+*Note*: use the absolute path instead of relative path to point to the configuration file on the host server. 
+
 [IoT REST API Server]: https://github.com/01org/iot-rest-api-server/
 [OCF]: https://openconnectivity.org/

--- a/ocf-servers/ocf-server.conf.template
+++ b/ocf-servers/ocf-server.conf.template
@@ -1,0 +1,4 @@
+#OCF_server number_of_servers
+fan 1
+led 2
+temperature 1

--- a/ocf-servers/start-ocf-servers-in-docker.sh
+++ b/ocf-servers/start-ocf-servers-in-docker.sh
@@ -1,17 +1,75 @@
 #!/bin/bash
 
+# project home directory
+PROJ_HOME=/opt/SmartHome-Demo
+
+# direcotry for ocf servers
+OCF_DIR=$PROJ_HOME/ocf-servers/js-servers
+
+# configuration file name
+CONFIG_FILE=$PROJ_HOME/ocf-servers/ocf-server.conf
+
 # Print out container IP address
 echo "This container IP address is: `hostname -i`"
 
 # Set-up the path to where the node.js modules were installed
-export NODE_PATH=/opt/SmartHome-Demo/ocf-servers/node_modules/
+export NODE_PATH=$PORJ_HOME/node_modules/
 
+
+parse_error=0
 # Start all different OCF servers available
-for file in `ls -1 /opt/SmartHome-Demo/ocf-servers/js-servers/*.js`
-do
-	/usr/bin/node $file -s &
-	sleep 0.2
-done
+if [ -f "$CONFIG_FILE" ];
+then
+    while read ocf_server_name num; do
+        # skip commented lines
+        if [[ $ocf_server_name =~ "^\#.*" ]];
+        then
+            continue
+        fi
+
+        if [ -f "$OCF_DIR/$ocf_server_name.js" ];
+        then
+            if [[ $num =~ ^[0-9]+$ ]];
+            then
+                for i in $(seq 1 $num);
+                do
+                    echo "...Start $ocf_server_name server..."
+                    if [ "$i" == "1" ];
+                    then 
+                        /usr/bin/node "$OCF_DIR/$ocf_server_name.js" -s &
+                    else
+                        # create a new ocf server file
+                        \cp -fR $OCF_DIR/$ocf_server_name.js $OCF_DIR/$ocf_server_name$i.js
+                        rt="'/a/$ocf_server_name$i',"
+                        sed -i "s#\(resourceInterfaceName\s*=\s*\).*#\1${rt}#" $OCF_DIR/$ocf_server_name$i.js
+                        if [ $? -eq 0 ]; 
+                        then
+                            /usr/bin/node "$OCF_DIR/$ocf_server_name$i.js" -s &
+                        else
+                            parse_error=1
+                            break
+                        fi
+                    fi
+                    sleep 0.2
+                done
+            else
+                parse_error=1
+                break
+            fi
+        fi
+    done < "$CONFIG_FILE"
+fi
+
+# conf file does not exist or got parsing error
+if [ "$parse_error" == "1" ] || [ ! -f "$CONFIG_FILE" ];
+then 
+    echo "Config file was incorrect or not found. Start all ocf servers by default."
+    for file in `ls -1 $OCF_DIR/*.js`
+    do
+	    /usr/bin/node $file -s &
+	    sleep 0.2
+    done
+fi
 
 keepgoing=true
 


### PR DESCRIPTION
The script searches and reads an ocf-server.conf file under the same directory (/opt/SmartHome-Demo/ocf-servers/) to decide how many OCF servers to start. 

Regarding starting OCF servers of the same type, the script creates a copy of the ocf-server file and renamed it to `<ocf-server><num>.js`. Then it changes the resource path in the `<ocf-server><num>.js`.  The new OCF server is identified as `uuid+resource_path$num` (eg. /a/fan1, /a/fan2). 

The ocf-server.conf file template is located in ocf-servers/ocf-server.conf.template. If the conf file does not exist, the script starts all the OCF servers by default. 

Add the parameter `-v <conf_path_on_host>:<conf_path_in_container>` to `docker run` command.
eg. `docker run -v /opt/SmartHome-Demo/ocf-server.conf:/opt/SmartHome-Demo/ocf-servers/ocf-server.conf smarthome-sensors:v1`

You may also want to pull the image from Dockerhub.
`docker pull xshan1/smarthome-demo:ocf-servers`

Signed-off-by: Theresa <theresa.shan@intel.com>